### PR TITLE
Moving custom properties to object to match other color api

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,10 +22,12 @@
   "color": {
     "crimson": "#eb0052"
   },
+  "properties": {
+    "gradient": "linear-gradient(var(--primary), var(--secondary))"
+  },
   "grid": {
     "steps": 6
   },
-  "properties": [],
   "queries": {
     "lg": "48em"
   },

--- a/properties.mjs
+++ b/properties.mjs
@@ -1,19 +1,16 @@
 export default function properties(state={}) {
   const { config } = state
-  const { properties=[] } = config
+  const { properties={} } = config
   let output = ''
-  if (properties.length) {
+  if (Object.keys(properties)) {
     output = /*css*/`
-  /* CUSTOM PROPERTIES */
-  :root {
+/* CUSTOM PROPERTIES */
+:root {
   `
-    properties.forEach(function (prop={}) {
-      let key = Object.keys(prop)[0]
-      output += `  --${key}:${prop[key]};/* ${key} */\n`
-    })
+ output +=  Object.keys(properties).map(key => `--${key}:${properties[key]};/* ${key} */`).join('\n')
 
-    output += `
-  }
+output += `
+}
   `
   }
 

--- a/theme.mjs
+++ b/theme.mjs
@@ -11,13 +11,13 @@ import stroke from './stroke.mjs'
 export default function theme(config) {
   return /*css*/`
 /* ----- THEME ----- */
+${themeColor({config})}
 ${properties({config})}
 ${reset()}
 ${typeface({config})}
 ${background({config})}
 ${border({config})}
 ${color({config})}
-${themeColor({config})}
 ${fill({config})}
 ${stroke({config})}
 `


### PR DESCRIPTION
The only thing left is to merge all custom properties ( aka variables ) to one `:root` definition. Now it outputs two `:root` definitions and I just won't stand for that. ;)