### PR TITLE
fluid image block size addition

### DIFF
--- a/reset.mjs
+++ b/reset.mjs
@@ -25,6 +25,7 @@ svg,
 video {
   display: block;
   max-width: 100%;
+  block-size: auto;
 }
 button,
 input,


### PR DESCRIPTION
I noticed in a project that images that have width and height attrs were stretching in the block direction. I think I recall this is a typical remedy.