### PR TITLE
Add class for screenreader only content

### DIFF
--- a/visibility.mjs
+++ b/visibility.mjs
@@ -1,7 +1,8 @@
-export default function overflow (query='') {
+export default function overflow(query = '') {
   return /*css*/`
 /*** Visibility ***/
 .invisible${query}{visibility:hidden;}
 .visible${query}{visibility:visible;}
+.screenreader-only${query}{border: 0; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; word-wrap: normal;}
 `
 }


### PR DESCRIPTION
Adds a class for visually hiding text content, but leaving it accessible for screenreaders.

Example usage:

```html
<h1>
  <img src="logo.svg" alt="" />
  <span class="screenreader-only">The Name Of Our Brand</span>
</h1>
```